### PR TITLE
Add keyboard support to inkview

### DIFF
--- a/goinkview.c
+++ b/goinkview.c
@@ -3,3 +3,7 @@
 int main_handler(int t, int p1, int p2) {
     return goMainHandler(t, p1, p2); 
 }
+
+void c_keyboard_handler(char* text) {
+    goKeyboardHandler(text);    
+}

--- a/keyboard.go
+++ b/keyboard.go
@@ -1,0 +1,46 @@
+package ink
+
+/*
+#include "inkview.h"
+
+#cgo CFLAGS: -pthread
+#cgo LDFLAGS: -pthread -lpthread -linkview
+
+extern void c_keyboard_handler(char *);
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+//export goKeyboardHandler
+func goKeyboardHandler(text *C.char) {
+	userKeyboardHandler(C.GoString(text))
+}
+
+type KeyboardHandler func(string)
+
+var userKeyboardHandler KeyboardHandler
+
+func SetKeyboardHandler(kh KeyboardHandler) {
+	userKeyboardHandler = kh
+}
+
+func OpenKeyboard(placeholder string, buflen int) {
+
+	if buflen <= 0 {
+		buflen = 1024
+	}
+
+	buffer := make([]byte, buflen)
+
+	ctitle := C.CString(placeholder)
+	defer C.free(unsafe.Pointer(ctitle))
+
+	cbuffer := (*C.char)(unsafe.Pointer(&buffer[0]))
+
+	var chandler C.iv_keyboardhandler
+	chandler = (C.iv_keyboardhandler)(C.c_keyboard_handler)
+
+	C.OpenKeyboard(ctitle, cbuffer, C.int(buflen), C.int(0), chandler)
+}

--- a/ui.go
+++ b/ui.go
@@ -75,3 +75,8 @@ func HideHourglass() {
 func DisableExitHourglass() {
 	C.DisableExitHourglass()
 }
+
+func DrawTopPanel() {
+	// Taken from the original sudoku.app, a pattern was identified that in applications this code is responsible for rendering the top bar.
+	C.DrawPanel(nil, C.CString(""), C.CString(""), -1)
+}

--- a/ui.go
+++ b/ui.go
@@ -25,6 +25,10 @@ const (
 	Error    = Icon(C.ICON_ERROR)
 )
 
+func SetMessageDelay(time time.Duration) {
+	DefaultDelay = time
+}
+
 func Message(icon Icon, title, text string, dt time.Duration) {
 	if dt == 0 {
 		dt = DefaultDelay

--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,8 @@ import (
 	"unsafe"
 )
 
+var defaultKeyboardLang = "en"
+
 func cbool(v bool) C.int {
 	if v {
 		return 1
@@ -109,4 +111,12 @@ func PowerOff() {
 
 func OpenMainMenu() {
 	C.OpenMainMenu()
+}
+
+func LoadKeyboard() {
+	C.LoadKeyboard(C.CString(defaultKeyboardLang))
+}
+
+func CloseKeyboard() {
+	C.CloseKeyboard()
 }


### PR DESCRIPTION
## Changes

* Added a new method to invoke the virtual keyboard
* Implemented a handler to process user input from the virtual keyboard
* Add top bar draw function

## Motivation
I was using the inkview library and found it to be almost perfect for my needs, but it lacked keyboard support. I've added this functionality to my fork and believe it would be beneficial to include it in the main repository.

Please review the changes and let me know if you have any questions or concerns. I'm happy to discuss and refine the implementation as needed.