### PR TITLE
Add keep connection

### DIFF
--- a/network.go
+++ b/network.go
@@ -86,3 +86,18 @@ func KeepNetwork() (func(), error) {
 	}
 	return nil, last
 }
+
+// Obtained through reverse engineering, automatically connecting to the network and maintaining an active connection
+// requires passing null instead of the network name. You should first use QueryNetwork.
+// If not connected display network select or warning message, return error if connection failed
+func ConnectDefault() error {
+	if int(C.NetConnect(nil)) != 0 {
+		return errors.New("Can't connect network")
+	}
+
+	return nil
+}
+
+func QueryNetwork() {
+	C.QueryNetwork()
+}

--- a/network.go
+++ b/network.go
@@ -11,7 +11,10 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"sync"
 )
+
+var queryNetworkOnce sync.Once
 
 // HwAddress returns device MAC address.
 func HwAddress() string {
@@ -88,9 +91,14 @@ func KeepNetwork() (func(), error) {
 }
 
 // Obtained through reverse engineering, automatically connecting to the network and maintaining an active connection
-// requires passing null instead of the network name. You should first use QueryNetwork.
+// requires passing null instead of the network name.
 // If not connected display network select or warning message, return error if connection failed
 func ConnectDefault() error {
+
+	queryNetworkOnce.Do(func() {
+		QueryNetwork()
+	})
+
 	if int(C.NetConnect(nil)) != 0 {
 		return errors.New("Can't connect network")
 	}


### PR DESCRIPTION
## Changes

* Implemented network connection activation in the application
* Added QueryNetwork and ConnectDefault methods for automatic network connection
* Fixed the issue with blocked network requests due to inactive connection

## Motivation

The current implementation of the network in the application does not work, despite being connected to WiFi. After conducting reverse engineering, it was discovered that calling the QueryNetwork and NetConnect(null) methods is necessary to activate the network connection. In this PR, these methods have been implemented, and the ConnectDefault method has been added, which performs NetConnect(null) to automatically connect to the network and maintain an active connection during the application's runtime.

Please review these changes and let me know if you have any questions or concerns. I'm happy to discuss and refine the implementation as needed.